### PR TITLE
More control delegated for external link resolvers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ export {
     type ComponentPath,
     type Meaning,
     type MeaningKeyword,
+    type ExternalResolveAttempt,
+    type ExternalResolveResult
 } from "./lib/converter";
 
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export {
     type Meaning,
     type MeaningKeyword,
     type ExternalResolveAttempt,
-    type ExternalResolveResult
+    type ExternalResolveResult,
 } from "./lib/converter";
 
 export {

--- a/src/lib/converter/comments/linkResolver.ts
+++ b/src/lib/converter/comments/linkResolver.ts
@@ -16,8 +16,12 @@ import { resolveDeclarationReference } from "./declarationReferenceResolver";
 const urlPrefix = /^(http|ftp)s?:\/\//;
 const brackets = /\[\[(?!include:)([^\]]+)\]\]/g;
 
-export type ExternalResolveResult = { target: string, caption: string }
-export type ExternalResolveAttempt = (ref: DeclarationReference, part: CommentDisplayPart, refl: Reflection) => ExternalResolveResult | string | undefined;
+export type ExternalResolveResult = { target: string; caption: string };
+export type ExternalResolveAttempt = (
+    ref: DeclarationReference,
+    part: CommentDisplayPart,
+    refl: Reflection
+) => ExternalResolveResult | string | undefined;
 
 export function resolveLinks(
     comment: Comment,
@@ -149,15 +153,20 @@ function resolveLinkTag(
             defaultDisplayText = target.name;
         } else {
             // If we didn't find a link, it might be a @link tag to an external symbol, check that next.
-            let externalResolveResult = attemptExternalResolve(declRef[0], part, reflection);
+            let externalResolveResult = attemptExternalResolve(
+                declRef[0],
+                part,
+                reflection
+            );
 
             switch (typeof externalResolveResult) {
-                case 'string':
+                case "string":
                     target = externalResolveResult as string;
                     defaultDisplayText = part.text.substring(0, pos);
                     break;
-                case 'object':
-                    externalResolveResult = externalResolveResult as ExternalResolveResult;
+                case "object":
+                    externalResolveResult =
+                        externalResolveResult as ExternalResolveResult;
                     part.target = externalResolveResult.target;
                     part.text = externalResolveResult.caption;
                     return part;

--- a/src/lib/converter/converter.ts
+++ b/src/lib/converter/converter.ts
@@ -78,7 +78,11 @@ export class Converter extends ChildableComponent<
 
     private _config?: CommentParserConfig;
     private _externalSymbolResolvers: Array<
-        (ref: DeclarationReference, part?: CommentDisplayPart, refl?: Reflection) => string | undefined
+        (
+            ref: DeclarationReference,
+            part?: CommentDisplayPart,
+            refl?: Reflection
+        ) => string | undefined
     > = [];
 
     get config(): CommentParserConfig {
@@ -274,7 +278,11 @@ export class Converter extends ChildableComponent<
     }
 
     /** @internal */
-    resolveExternalLink(ref: DeclarationReference, part?: CommentDisplayPart, refl?: Reflection): string | undefined {
+    resolveExternalLink(
+        ref: DeclarationReference,
+        part?: CommentDisplayPart,
+        refl?: Reflection
+    ): string | undefined {
         for (const resolver of this._externalSymbolResolvers) {
             const resolved = resolver(ref, part, refl);
             if (resolved) return resolved;

--- a/src/lib/converter/converter.ts
+++ b/src/lib/converter/converter.ts
@@ -78,7 +78,7 @@ export class Converter extends ChildableComponent<
 
     private _config?: CommentParserConfig;
     private _externalSymbolResolvers: Array<
-        (ref: DeclarationReference) => string | undefined
+        (ref: DeclarationReference, part?: CommentDisplayPart, refl?: Reflection) => string | undefined
     > = [];
 
     get config(): CommentParserConfig {
@@ -274,9 +274,9 @@ export class Converter extends ChildableComponent<
     }
 
     /** @internal */
-    resolveExternalLink(ref: DeclarationReference): string | undefined {
+    resolveExternalLink(ref: DeclarationReference, part?: CommentDisplayPart, refl?: Reflection): string | undefined {
         for (const resolver of this._externalSymbolResolvers) {
-            const resolved = resolver(ref);
+            const resolved = resolver(ref, part, refl);
             if (resolved) return resolved;
         }
     }
@@ -296,7 +296,7 @@ export class Converter extends ChildableComponent<
                 owner,
                 this.validation,
                 this.owner.logger,
-                (ref) => this.resolveExternalLink(ref)
+                (ref, part, refl) => this.resolveExternalLink(ref, part, refl)
             );
         } else {
             let warned = false;
@@ -315,7 +315,7 @@ export class Converter extends ChildableComponent<
                 warn,
                 this.validation,
                 this.owner.logger,
-                (ref) => this.resolveExternalLink(ref)
+                (ref, part, refl) => this.resolveExternalLink(ref, part, refl)
             );
         }
     }

--- a/src/lib/converter/index.ts
+++ b/src/lib/converter/index.ts
@@ -9,5 +9,9 @@ export type {
     Meaning,
     MeaningKeyword,
 } from "./comments/declarationReference";
+export type {
+    ExternalResolveAttempt,
+    ExternalResolveResult
+} from "./comments/linkResolver"
 
 import "./plugins/index";

--- a/src/lib/converter/index.ts
+++ b/src/lib/converter/index.ts
@@ -11,7 +11,7 @@ export type {
 } from "./comments/declarationReference";
 export type {
     ExternalResolveAttempt,
-    ExternalResolveResult
-} from "./comments/linkResolver"
+    ExternalResolveResult,
+} from "./comments/linkResolver";
 
 import "./plugins/index";


### PR DESCRIPTION
Adding external link resolvers was a great idea, but in fact, it is useless for `{@link} tags which cannot be resolved` (from documentation), because `linkResolver` passes into external resolvers only `DeclarationReference`, that will be invalid for links in formats that is not supported. So external resolver will know about fact that some link can't be resolved, but can't do anything
 about it.
 
I offer an improvement:
- Pass additional information (`part: CommentDisplayPart` and `reflection: Reflection`) to external resolver
- Allow external resolver control both target and text of link
- Add an exported `ExternalResolveAttempt` and `ExternalResolveResult` types as API for external resolver